### PR TITLE
Fixed byte/string bug in python3 env

### DIFF
--- a/pygreen.py
+++ b/pygreen.py
@@ -127,7 +127,7 @@ class PyGreen:
             if not os.path.exists(d):
                 os.makedirs(d)
             with open(loc, "w") as file_:
-                file_.write(content)
+                file_.write(content.decode('utf-8'))
 
     def cli(self, cmd_args=None):
         """


### PR DESCRIPTION
Signed-off-by: Wang wangwangwar@gmail.com

When I run "$pygreen gen output" in python2 it's OK, but in python3 env, I got this error:

Traceback (most recent call last):
File "/usr/bin/pygreen", line 5, in 
pygreen.cli()
File "/usr/lib/python3.3/site-packages/pygreen.py", line 157, in cli
args.func()
File "/usr/lib/python3.3/site-packages/pygreen.py", line 152, in gen
pygreen.gen_static(args.output)
File "/usr/lib/python3.3/site-packages/pygreen.py", line 130, in gen_static
file_.write(content)
TypeError: must be str, not bytes

It seems python3 differ byte and string more clearly.
I add a explicit byte->str call and it works both in python2 and 3.
